### PR TITLE
Axios Header Assignment Error

### DIFF
--- a/src/lib/middleware/send_axios_request_middleware.ts
+++ b/src/lib/middleware/send_axios_request_middleware.ts
@@ -156,7 +156,7 @@ export default class SendAxiosRequestMiddleware {
         caller: request.ip,
       });
 
-      configuration.headers.origin = transformedOrigin;
+      configuration.headers["origin"] = transformedOrigin;
     }
 
     const transformedReferer = request.context.get('transformedReferer') as string;
@@ -170,7 +170,7 @@ export default class SendAxiosRequestMiddleware {
         caller: request.ip,
       });
 
-      configuration.headers.referer = transformedReferer;
+      configuration.headers["referer"] = transformedReferer;
     }
 
     if (!axiosEnvironment.singleton.enableCertificateValidation) {


### PR DESCRIPTION
Change assignments for configuration.headers on origin and referer to string based indexing. Axios decided to make these not exist anymore :?